### PR TITLE
Add fast reverse anneal params info getter

### DIFF
--- a/dwave/experimental/fast_reverse_anneal/__init__.py
+++ b/dwave/experimental/fast_reverse_anneal/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .api import *

--- a/dwave/experimental/fast_reverse_anneal/api.py
+++ b/dwave/experimental/fast_reverse_anneal/api.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 
 from dwave.cloud import Client
 
-__all__ = ['get_solver_name']
+__all__ = ['get_solver_name', 'get_parameter_ranges']
 
 
 def get_solver_name() -> str:
@@ -31,3 +31,23 @@ def get_solver_name() -> str:
     with Client.from_config() as client:
         solver = client.get_solver(**filter)
         return solver.name
+
+
+def get_parameter_ranges(solver_name: str) -> dict[str, Any]:
+    """Retrieve available fast annealing parameter ranges."""
+
+    with Client.from_config() as client:
+        solver = client.get_solver(name=solver_name)
+
+        # get FRA param ranges
+        x_ret = solver.sample_qubo(
+            {next(iter(solver.edges)): 0},
+            x_get_fast_reverse_anneal_exp_feature_info=True)
+
+        info = x_ret.result().get('x_get_fast_reverse_anneal_exp_feature_info')
+        info = dict(zip(info[::2], info[1::2]))
+
+        return {
+            'x_target_c': info['long-name'],
+            'x_nominal_dwell_time': info['long-name'],
+        }

--- a/dwave/experimental/fast_reverse_anneal/api.py
+++ b/dwave/experimental/fast_reverse_anneal/api.py
@@ -1,0 +1,33 @@
+# Copyright 2025 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from dwave.cloud import Client
+
+__all__ = ['get_solver_name']
+
+
+def get_solver_name() -> str:
+    """Return the first available solver with fast reverse annealing enabled."""
+
+    # TODO: use feature-based solver selection to get a FRA solver
+    # NOTE: until we can use FBSS for FRA, we use a hard-coded name (prefix)
+    filter = dict(name__regex=r'Advantage2_prototype2.*|Advantage2_research1\..*')
+
+    with Client.from_config() as client:
+        solver = client.get_solver(**filter)
+        return solver.name

--- a/releasenotes/notes/add-fra-api-get-params-fb2a29ecec474981.yaml
+++ b/releasenotes/notes/add-fra-api-get-params-fb2a29ecec474981.yaml
@@ -3,4 +3,4 @@ features:
   - |
     Add ``dwave.experimental.fast_reverse_anneal`` submodule with a utility
     function to fetch available annealing parameters and their extended type
-    info (like allowed values, etc).
+    information (such as allowed values, etc).

--- a/releasenotes/notes/add-fra-api-get-params-fb2a29ecec474981.yaml
+++ b/releasenotes/notes/add-fra-api-get-params-fb2a29ecec474981.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add ``dwave.experimental.fast_reverse_anneal`` submodule with a utility
+    function to fetch available annealing parameters and their extended type
+    info (like allowed values, etc).

--- a/tests/test_fast_reverse_anneal.py
+++ b/tests/test_fast_reverse_anneal.py
@@ -1,0 +1,40 @@
+# Copyright 2025 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import unittest.mock
+
+from dwave.experimental.fast_reverse_anneal import get_parameters
+
+
+class FRA(unittest.TestCase):
+
+    def test_sampler_params(self):
+        x_target_c_range = [0, 1]
+        x_nominal_pause_time_values = [0, 1, 2]
+        info = ['fastReverseAnnealTargetCRange', x_target_c_range,
+                'fastReverseAnnealNominalPauseTimeValues', x_nominal_pause_time_values]
+
+        with unittest.mock.MagicMock() as sampler:
+            sampler.solver.edges = [(0,1)]
+            sampler.solver.sample_qubo.return_value.result.return_value = \
+                dict(x_get_fast_reverse_anneal_exp_feature_info=info)
+
+            p = get_parameters(sampler)
+
+            self.assertIn('x_target_c', p)
+            self.assertEqual(p['x_target_c']['limits']['range'], x_target_c_range)
+
+            self.assertIn('x_nominal_pause_time', p)
+            self.assertEqual(p['x_nominal_pause_time']['limits']['set'], x_nominal_pause_time_values)


### PR DESCRIPTION
Implement a simple interface to query available fast-reverse-anneal parameters.

If an active `DWaveSampler` is available:
```python
>>> from dwave.system import DWaveSampler
>>> from dwave.experimental import fast_reverse_anneal as fra
>>>
>>> with DWaveSampler() as sampler:
>>>     fra.get_parameters(sampler)
{'x_target_c': {'type': 'float',
  'required': True,
  'limits': {'range': [0, 1]},
  'description': 'The lowest value of the normalized control bias, `c(s)`, during a fast reverse annealing.'},
 'x_nominal_pause_time': {'type': 'float',
  'required': False,
  'default': 0.0,
  'limits': {'set': [0.0, 0.01, 0.02, 0.03, 0.04, 0.05]},
  'description': 'Sets the pause duration for fast-reverse-annealing schedules.'}}
```

If not, a default solver is used and params fetched:
```python
>>> from dwave.experimental.fast_reverse_anneal import get_parameters
>>> get_parameters()
{'x_target_c': {'type': 'float',
...
```

To make sure a FRA solver is used, you can use the built-in filter `SOLVER_FILTER`:
```python
>>> from dwave.system import DWaveSampler
>>> import dwave.experimental.fast_reverse_anneal as fra
>>> with DWaveSampler(solver=fra.SOLVER_FILTER) as sampler:
>>>     ...
```