### PR TITLE
Release 2026.4.20

### DIFF
--- a/dwave/experimental/__init__.py
+++ b/dwave/experimental/__init__.py
@@ -14,4 +14,4 @@
 
 # use CalVer: YYYY.M.D[.PATCH][rcN|.devN]
 # make no backwards compatibility guarantees
-__version__ = "2026.2.13"
+__version__ = "2026.4.20"

--- a/releasenotes/notes/update-solver-regex-9f83ca3baa52c494.yaml
+++ b/releasenotes/notes/update-solver-regex-9f83ca3baa52c494.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    Update ``SOLVER_FILTER`` regex to correctly match the new naming pattern,
+    with minor version optional (using ``graph_id`` to track working graph
+    changes).


### PR DESCRIPTION
### Other Notes

- Update `SOLVER_FILTER` regex to correctly match the new naming
  pattern, with minor version optional (using `graph_id` to track
  working graph changes).
